### PR TITLE
Fix OFX utilities and add tests

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,70 @@
+import hashlib
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from utils.build_ofx import build_ofx
+from utils.date_time import ofx_datetime, parse_time_to_timedelta
+from utils.id import make_fitid
+
+
+def test_ofx_datetime_formats_timestamp():
+    ts = pd.Timestamp("2023-05-01 12:34:56", tz="UTC")
+    assert ofx_datetime(ts) == "20230501123456.000[0:UTC]"
+
+
+def test_ofx_datetime_handles_none():
+    assert ofx_datetime(None) is None
+    assert ofx_datetime(pd.NaT) is None
+
+
+def test_parse_time_to_timedelta_parses_strings():
+    td = parse_time_to_timedelta("1:30 PM")
+    assert td == pd.to_timedelta(13, unit="h") + pd.to_timedelta(30, unit="m")
+
+
+def test_make_fitid_prefers_existing_value():
+    row = pd.Series({"fitid": " existing ", "amount_clean": 10})
+    assert make_fitid(row, 0) == "existing"
+
+
+def test_make_fitid_generates_deterministic_hash():
+    row = pd.Series(
+        {
+            "fitid": None,
+            "fitid_norm": None,
+            "date_parsed": pd.Timestamp("2023-05-01", tz="UTC"),
+            "amount_clean": 12.34,
+            "cleaned_desc": "Test Transaction",
+            "memo": "memo",
+            "name": "name",
+        }
+    )
+    expected = hashlib.md5(
+        "20230501000000.000[0:UTC]|12.34|Test Transaction|memo|name|0".encode()
+    ).hexdigest().upper()
+    assert make_fitid(row, 0) == expected
+
+
+def test_build_ofx_uses_transaction_date_range():
+    df = pd.DataFrame(
+        {
+            "date_parsed": [
+                pd.Timestamp("2023-01-01", tz="UTC"),
+                pd.Timestamp("2023-01-03", tz="UTC"),
+            ],
+            "amount_clean": [10.0, -5.0],
+            "trntype_norm": ["CREDIT", "DEBIT"],
+            "fitid_norm": ["ABC123", None],
+            "cleaned_desc": ["Deposit", "Withdrawal"],
+        }
+    )
+
+    ofx_text = build_ofx(df, accttype="checking", acctid="12345")
+
+    assert "<DTSTART>20230101000000.000[0:UTC]</DTSTART>" in ofx_text
+    assert "<DTEND>20230103000000.000[0:UTC]</DTEND>" in ofx_text
+    assert "<FITID>ABC123</FITID>" in ofx_text

--- a/utils/build_ofx.py
+++ b/utils/build_ofx.py
@@ -43,7 +43,7 @@ def build_ofx(
         }:
         accttype = "CHECKING"
     
-    if "date_parsed" not in df_txn.any() or not df_txn["date_parsed"].notna().any():
+    if "date_parsed" not in df_txn.columns or not df_txn["date_parsed"].notna().any():
         dtstart_ts = dtend_ts = now
     else:
         dtstart_ts = df_txn["date_parsed"].min()

--- a/utils/etl.py
+++ b/utils/etl.py
@@ -9,7 +9,7 @@ from utils.cleaning import (
     clean_description,
     infer_trntype_series,
     )
-from date_time import parse_time_to_timedelta
+from utils.date_time import parse_time_to_timedelta
 from utils.sheet import find_best_sheet, normalize_columns, detect_columns
 
 # ---------- ETL ----------

--- a/utils/id.py
+++ b/utils/id.py
@@ -6,19 +6,32 @@ import pandas as pd
 
 from utils.date_time import ofx_datetime
 
+
 # ---------- ids ----------
-def make_fitid(row: pd.DataFrame, idx: int) -> str:
-    if "fitid" not in row.any() or pd.notna(row["fitid"]).empty:
-        parts = [
-            ofx_datetime(row.get("date_parsed")),
-            f"{row.get('amount_clean', '')}",
-            str(row.get("cleaned_desc", ""))[:64],
-            str(row.get("memo", ""))[:64],
-            str(row.get("name", ""))[:64],
-            str(idx),
-            ]
-        return hashlib.md5("|".join(parts).encode()).hexdigest().upper()
-    return str(row["fitid"])[:32]
+def _normalize_fitid(value) -> str:
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return ""
+
+    text = str(value).strip()
+    return "" if not text or text.lower() == "nan" else text
+
+
+def make_fitid(row: pd.Series, idx: int) -> str:
+    fitid = _normalize_fitid(row.get("fitid")) or _normalize_fitid(
+        row.get("fitid_norm")
+    )
+    if fitid:
+        return fitid[:32]
+
+    parts = [
+        ofx_datetime(row.get("date_parsed")) or "",
+        f"{row.get('amount_clean', '')}",
+        str(row.get("cleaned_desc", ""))[:64],
+        str(row.get("memo", ""))[:64],
+        str(row.get("name", ""))[:64],
+        str(idx),
+    ]
+    return hashlib.md5("|".join(parts).encode()).hexdigest().upper()
 
 def derive_acctid_from_path(path: Path, default_stub: str) -> str:
     digits = re.sub(r"[^0-9]", "", path.stem)


### PR DESCRIPTION
## Summary
- fix OFX datetime formatting and ensure transaction date ranges are respected when building files
- correct utility imports and FITID generation to avoid runtime errors and better reuse provided identifiers
- add regression tests covering datetime helpers, FITID generation, and OFX date handling

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d5ff93aad0832090d422981a83a474