### PR TITLE
Remove unused NLP dependencies

### DIFF
--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ Process Excel files containing bank transaction data, normalize and clean the da
 infer transaction types, and generate OFX files for financial software import.
 
 Usage:
-    pip3 install -r requirements.txt
+    pip3 install -r requirements.txt  # installs pandas, numpy, openpyxl, python-dateutil
     python main.py
 
 Edit the paths in the __main__ section to point to your checking and savings account Excel files.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,4 @@
 pandas
 numpy
-uuid
 openpyxl
-spacy
-dateparser
-rapidfuzz
-spacy-langdetect
 python-dateutil


### PR DESCRIPTION
## Summary
- remove unused NLP-related dependencies from requirements.txt
- clarify main.py usage comment to reflect the streamlined dependency set

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d60b1930648320a52c333f6b8c5879