### PR TITLE
Add regression test for build_ofx amount validation

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -184,6 +184,18 @@ def test_build_ofx_uses_fallback_timestamp_for_ranges():
     assert f"<DTSTART>{fallback_str}</DTSTART>" in ofx_text
     assert f"<DTEND>{fallback_str}</DTEND>" in ofx_text
 
+
+def test_build_ofx_requires_amount_column():
+    df = pd.DataFrame(
+        {
+            "date_parsed": [pd.Timestamp("2024-01-01", tz="UTC")],
+        }
+    )
+
+    with pytest.raises(ValueError, match="amount_clean"):
+        build_ofx(df, accttype="checking", acctid="12345")
+
+
 def test_infer_trntype_series_uses_custom_rules(tmp_path):
     config_path = tmp_path / "rules.json"
     config_path.write_text(


### PR DESCRIPTION
## Summary
- add a regression test ensuring build_ofx fails when amount_clean is missing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d60a47c7448320a03ffe44e9234e28