### PR TITLE
Add optional LLM enrichment to ETL pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# OFX File Creator
+
+This project helps transform raw bank or credit card exports into OFX files that can be
+imported into personal finance tools. The utilities under `utils/` normalize common CSV
+fields, clean descriptions, infer transaction types, and assemble OFX-compliant output.
+
+## LLM-powered enrichment (optional)
+
+Some workflows benefit from model-generated payee names or categories. The
+`utils.llm_enrichment.enrich_transactions_with_llm` helper can be enabled via the
+`load_and_prepare` function:
+
+```python
+from utils.etl import load_and_prepare
+from utils.llm_enrichment import enrich_transactions_with_llm
+
+client = ...  # your LLM SDK client
+prepared = load_and_prepare(path_to_csv, llm_client=client, llm_batch_size=10)
+```
+
+When an `llm_client` is supplied, the loader will batch transactions and send prompts
+containing the raw description, the selected payee display text, and the cleaned
+description. The model is asked to emit minified JSON with `payee`, `category`, and
+`description` fields. Parsed results are added to the dataframe as `payee_llm`,
+`category_llm`, and `description_llm` columns.
+
+### Configuring clients
+
+* **API keys** – Follow the vendor instructions for your chosen SDK (e.g., OpenAI,
+  Anthropic). Export any required tokens (such as `OPENAI_API_KEY`) before running the
+  enrichment step.
+* **Batch sizing** – Adjust `llm_batch_size` to match the provider's rate limits. The
+  default of 20 rows keeps requests small and avoids long prompts.
+* **Cost awareness** – LLM calls can be expensive. Estimate token usage from the
+  prompt template and size your batches accordingly. For exploratory runs, point the
+  client at a lower-cost model or reduce the batch size.
+
+### Using mlx-lm locally
+
+Apple silicon users can rely on [`mlx-lm`](https://github.com/ml-explore/mlx-examples)
+for local inference. Load the model with `mlx_lm.utils.load` (or `mlx_lm.load`) and
+pass a configuration dictionary to `load_and_prepare`:
+
+```python
+from mlx_lm import load as mlx_load
+
+model, tokenizer = mlx_load("mlx-community/Llama-3.2-3B-Instruct-4bit")
+
+client = {
+    "framework": "mlx_lm",  # tells the helper to use the mlx integration
+    "model": model,
+    "tokenizer": tokenizer,
+    "generation_kwargs": {"max_tokens": 128},  # forwarded to mlx_lm.generate
+}
+
+prepared = load_and_prepare(path_to_csv, llm_client=client, llm_batch_size=10)
+```
+
+Set `use_batch=False` in the configuration if you prefer to call `mlx_lm.generate`
+per prompt instead of batching through `mlx_lm.batch_generate`. Remember that mlx-lm
+requires the base [`mlx`](https://pypi.org/project/mlx/) package, which is only
+available on recent macOS releases.
+
+### Offline or air-gapped usage
+
+Leave `llm_client=None` (the default) to skip enrichment entirely. The OFX generation
+pipeline remains fully functional without model calls, making it safe to run offline or
+in environments without API access.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@ import hashlib
 import json
 import re
 import sys
+import types
 from pathlib import Path
 
 import pandas as pd
@@ -17,6 +18,7 @@ from utils.validate import assert_ofx_ready
 
 from utils.rules import load_rules
 from utils.etl import load_and_prepare
+from utils.llm_enrichment import enrich_transactions_with_llm
 
 
 @pytest.fixture
@@ -237,5 +239,156 @@ def test_load_and_prepare_handles_csv(sample_transaction_csv):
 
     assert "date_parsed" in df.columns
     assert pd.Timestamp("2023-01-02", tz="UTC") == df.loc[0, "date_parsed"]
-    
+
+
+class FakeLLMClient:
+    def __init__(self):
+        self.calls = []
+
+    def generate_batch(self, prompts):
+        self.calls.append(list(prompts))
+        responses = []
+        for prompt in prompts:
+            if "Coffee" in prompt:
+                responses.append(
+                    json.dumps(
+                        {
+                            "payee": "Daily Grind Coffee",
+                            "category": "Food & Drink",
+                            "description": "Coffee purchase",
+                        }
+                    )
+                )
+            elif "Hardware" in prompt:
+                responses.append(
+                    "Here you go: {\"payee\": \"Ace Hardware\","
+                    " \"category\": \"Home Improvement\","
+                    " \"description\": \"Hardware run\"}"
+                )
+            else:
+                responses.append("No idea")
+        return responses
+
+
+def test_enrich_transactions_with_llm_batches_and_failures():
+    df = pd.DataFrame(
+        {
+            "raw_desc": ["Coffee Shop", "Weekend Hardware", "Unknown"],
+            "payee_display": ["Coffee Shop", "Hardware Store", "Mystery"],
+            "cleaned_desc": ["coffee", "hardware", ""],
+        }
+    )
+
+    client = FakeLLMClient()
+    enriched = enrich_transactions_with_llm(df, client, batch_size=2)
+
+    assert list(enriched.columns) == [
+        "payee_llm",
+        "category_llm",
+        "description_llm",
+    ]
+    assert enriched.loc[0, "payee_llm"] == "Daily Grind Coffee"
+    assert enriched.loc[1, "category_llm"] == "Home Improvement"
+    assert pd.isna(enriched.loc[2, "payee_llm"])
+    assert len(client.calls) == 2
+
+
+def test_enrich_transactions_with_llm_supports_mlx(monkeypatch):
+    df = pd.DataFrame(
+        {
+            "raw_desc": ["Coffee Shop", "Weekend Hardware", "Unknown"],
+            "payee_display": ["Coffee Shop", "Hardware Store", "Mystery"],
+            "cleaned_desc": ["coffee", "hardware", ""],
+        }
+    )
+
+    fake_module = types.ModuleType("mlx_lm")
+    fake_module.calls = []
+
+    class FakeTokenizer:
+        eos_token_ids = [0]
+
+        def __call__(self, prompt, **kwargs):
+            tokens = [ord(ch) for ch in prompt]
+            return types.SimpleNamespace(input_ids=[tokens])
+
+        def decode(self, tokens):
+            return "".join(chr(i) for i in tokens)
+
+    fake_tokenizer = FakeTokenizer()
+
+    def response_for_prompt(text):
+        if "Coffee" in text:
+            return json.dumps(
+                {
+                    "payee": "Daily Grind Coffee",
+                    "category": "Food & Drink",
+                    "description": "Coffee purchase",
+                }
+            )
+        if "Hardware" in text:
+            return json.dumps(
+                {
+                    "payee": "Ace Hardware",
+                    "category": "Home Improvement",
+                    "description": "Hardware run",
+                }
+            )
+        return "No idea"
+
+    def fake_batch_generate(model, tokenizer, prompts, **kwargs):
+        fake_module.calls.append(("batch", prompts, kwargs))
+        texts = [response_for_prompt(tokenizer.decode(p)) for p in prompts]
+        return types.SimpleNamespace(texts=texts)
+
+    def fake_generate(model, tokenizer, prompt, **kwargs):
+        fake_module.calls.append(("single", prompt, kwargs))
+        return response_for_prompt(prompt)
+
+    fake_module.batch_generate = fake_batch_generate
+    fake_module.generate = fake_generate
+
+    monkeypatch.setitem(sys.modules, "mlx_lm", fake_module)
+
+    client = {
+        "model": object(),
+        "tokenizer": fake_tokenizer,
+        "framework": "mlx_lm",
+        "generation_kwargs": {"max_tokens": 64},
+    }
+
+    enriched_batch = enrich_transactions_with_llm(df, client, batch_size=3)
+
+    assert enriched_batch.loc[0, "payee_llm"] == "Daily Grind Coffee"
+    assert enriched_batch.loc[1, "category_llm"] == "Home Improvement"
+    assert pd.isna(enriched_batch.loc[2, "payee_llm"])
+    assert fake_module.calls and fake_module.calls[0][0] == "batch"
+
+    fake_module.calls = []
+    client_single = {**client, "use_batch": False}
+    enriched_single = enrich_transactions_with_llm(df, client_single, batch_size=2)
+
+    pd.testing.assert_frame_equal(enriched_single, enriched_batch)
+    assert len(fake_module.calls) == len(df)
+    assert all(call[0] == "single" for call in fake_module.calls)
+
+
+def test_load_and_prepare_enriches_when_llm_client_provided(tmp_path):
+    csv_path = tmp_path / "transactions.csv"
+    pd.DataFrame(
+        {
+            "Date": ["2023-05-01", "2023-05-02"],
+            "Amount": ["10.00", "25.00"],
+            "Description": ["Coffee Shop", "Weekend Hardware"],
+            "Payee": ["Coffee Shop", "Hardware Store"],
+        }
+    ).to_csv(csv_path, index=False)
+
+    client = FakeLLMClient()
+    df = load_and_prepare(csv_path, llm_client=client, llm_batch_size=1)
+
+    assert "payee_llm" in df.columns
+    assert df.loc[0, "payee_llm"] == "Daily Grind Coffee"
+    assert df.loc[0, "category_llm"] == "Food & Drink"
+    assert df.loc[1, "payee_llm"] == "Ace Hardware"
 

--- a/utils/llm_enrichment.py
+++ b/utils/llm_enrichment.py
@@ -1,0 +1,312 @@
+"""Utilities for enriching transactions with large language models."""
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass
+from collections.abc import Mapping
+from typing import Any, Dict, List, Optional, Sequence
+
+import pandas as pd
+
+logger = logging.getLogger(__name__)
+
+_PROMPT_TEMPLATE = (
+    "You are a financial data enrichment assistant.\n"
+    "Given details about a bank transaction, infer the best-guess payee name,\n"
+    "the spending category, and a concise user-facing description.\n"
+    "Respond ONLY with minified JSON following this schema:\n"
+    '{{"payee": string | null, "category": string | null, "description": string | null}}.\n'
+    "If you are unsure, use null for that field.\n\n"
+    "Transaction data:\n"
+    "- Raw description: {raw_desc}\n"
+    "- Payee display: {payee_display}\n"
+    "- Cleaned description: {cleaned_desc}\n\n"
+    "Return only the JSON object with double quotes."
+)
+
+
+@dataclass
+class _ClientInvoker:
+    client: object
+
+    def invoke(self, prompts: Sequence[str]) -> List[str]:
+        """Call the provided LLM client and return a list of response strings."""
+
+        mlx_result = _try_mlx_lm_invocation(self.client, prompts)
+        if mlx_result is not None:
+            return mlx_result
+
+        if hasattr(self.client, "generate_batch"):
+            return list(self.client.generate_batch(list(prompts)))
+
+        if callable(self.client):
+            return [str(self.client(prompt)) for prompt in prompts]
+
+        if hasattr(self.client, "generate"):
+            return [str(getattr(self.client, "generate")(prompt)) for prompt in prompts]
+
+        raise AttributeError(
+            "LLM client must provide a 'generate_batch', 'generate', or be callable"
+        )
+
+
+def _coerce_str(value: object):
+    if value is None:
+        return pd.NA
+    try:
+        if pd.isna(value):
+            return pd.NA
+    except TypeError:
+        pass
+    text = str(value).strip()
+    return text if text else pd.NA
+
+
+def _safe_value(value: object) -> str:
+    if value is None:
+        return ""
+    try:
+        if pd.isna(value):
+            return ""
+    except TypeError:
+        pass
+    text = str(value)
+    return text if text else ""
+
+
+def _parse_response(raw: object) -> dict:
+    if isinstance(raw, dict):
+        return raw
+
+    text = str(raw).strip()
+    if not text:
+        raise ValueError("empty response")
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    start = text.find("{")
+    end = text.rfind("}")
+    if start != -1 and end != -1 and end > start:
+        snippet = text[start : end + 1]
+        return json.loads(snippet)
+
+    raise ValueError("Could not parse JSON from response")
+
+
+def enrich_transactions_with_llm(
+    df: pd.DataFrame,
+    client,
+    *,
+    batch_size: int = 20,
+) -> pd.DataFrame:
+    """Use an LLM to enrich transaction data.
+
+    Parameters
+    ----------
+    df: pandas.DataFrame
+        Must contain ``raw_desc``, ``payee_display`` and ``cleaned_desc`` columns.
+    client: object
+        LLM client supporting ``generate_batch`` (preferred), ``generate``, or
+        being directly callable with a prompt string.
+    batch_size: int, default 20
+        Number of rows per batch request.
+    """
+
+    required_cols = {"raw_desc", "payee_display", "cleaned_desc"}
+    missing = required_cols - set(df.columns)
+    if missing:
+        raise ValueError(
+            "DataFrame must contain the columns: " + ", ".join(sorted(missing))
+        )
+
+    if batch_size <= 0:
+        raise ValueError("batch_size must be positive")
+
+    invoker = _ClientInvoker(client)
+
+    index = list(df.index)
+    prompts = [
+        _PROMPT_TEMPLATE.format(
+            raw_desc=_safe_value(df.at[idx, "raw_desc"]),
+            payee_display=_safe_value(df.at[idx, "payee_display"]),
+            cleaned_desc=_safe_value(df.at[idx, "cleaned_desc"]),
+        )
+        for idx in index
+    ]
+
+    payee_series = pd.Series(pd.NA, index=index, dtype="string")
+    category_series = pd.Series(pd.NA, index=index, dtype="string")
+    description_series = pd.Series(pd.NA, index=index, dtype="string")
+
+    for start in range(0, len(prompts), batch_size):
+        batch_prompts = prompts[start : start + batch_size]
+        batch_indices = index[start : start + len(batch_prompts)]
+        try:
+            responses = invoker.invoke(batch_prompts)
+        except Exception as exc:  # pragma: no cover - logging side-effect
+            logger.warning("LLM enrichment request failed: %s", exc)
+            continue
+
+        if len(responses) != len(batch_prompts):
+            logger.warning(
+                "LLM client returned %s responses for %s prompts",
+                len(responses),
+                len(batch_prompts),
+            )
+            continue
+
+        for idx, raw_response in zip(batch_indices, responses):
+            try:
+                data = _parse_response(raw_response)
+            except Exception as exc:  # pragma: no cover - logging side-effect
+                logger.debug("Could not parse LLM response for index %s: %s", idx, exc)
+                continue
+
+            payee_series.at[idx] = _coerce_str(data.get("payee"))
+            category_series.at[idx] = _coerce_str(data.get("category"))
+            description_series.at[idx] = _coerce_str(data.get("description"))
+
+    return pd.DataFrame(
+        {
+            "payee_llm": payee_series,
+            "category_llm": category_series,
+            "description_llm": description_series,
+        }
+    )
+
+
+def _try_mlx_lm_invocation(client: object, prompts: Sequence[str]) -> Optional[List[str]]:
+    """Attempt to route prompts through an ``mlx-lm`` client configuration."""
+
+    config = _resolve_mlx_client_config(client)
+    if config is None:
+        return None
+
+    try:
+        # Import lazily so downstream projects without mlx-lm installed still work.
+        import importlib
+
+        mlx_module = importlib.import_module("mlx_lm")
+    except Exception as exc:  # pragma: no cover - environment-specific
+        raise RuntimeError(
+            "mlx_lm is required for this client configuration but could not be imported"
+        ) from exc
+
+    batch_fn = config.get("batch_generate") or getattr(mlx_module, "batch_generate", None)
+    generate_fn = config.get("generate") or getattr(mlx_module, "generate", None)
+
+    model = config["model"]
+    tokenizer = config["tokenizer"]
+    tokenize_kwargs = config.get("tokenize_kwargs", {})
+    generation_kwargs = dict(config.get("generation_kwargs", {}))
+    max_tokens = generation_kwargs.pop("max_tokens", None)
+
+    if batch_fn is not None and config.get("use_batch", True):
+        tokens = [
+            _tokenize_for_mlx(tokenizer, prompt, tokenize_kwargs)
+            for prompt in prompts
+        ]
+        batch_kwargs = dict(generation_kwargs)
+        if max_tokens is not None:
+            batch_kwargs.setdefault("max_tokens", max_tokens)
+        responses = batch_fn(model, tokenizer, tokens, **batch_kwargs)
+        texts = getattr(responses, "texts", responses)
+        return [str(text) for text in texts]
+
+    if generate_fn is None:
+        raise AttributeError(
+            "mlx_lm client must supply a 'generate' function when batch generation is disabled"
+        )
+
+    single_kwargs = dict(generation_kwargs)
+    if max_tokens is not None:
+        single_kwargs.setdefault("max_tokens", max_tokens)
+
+    outputs = [
+        str(generate_fn(model, tokenizer, prompt=prompt, **single_kwargs))
+        for prompt in prompts
+    ]
+    return outputs
+
+
+def _resolve_mlx_client_config(client: object) -> Optional[Dict[str, Any]]:
+    """Extract mlx-lm configuration from supported client shapes."""
+
+    data: Optional[Dict[str, Any]] = None
+    if isinstance(client, Mapping):
+        data = dict(client)
+    elif isinstance(client, tuple) and len(client) in (2, 3):
+        data = {"model": client[0], "tokenizer": client[1]}
+        if len(client) == 3 and isinstance(client[2], Mapping):
+            data.update(client[2])
+
+    if not data:
+        return None
+
+    framework = None
+    for key in ("framework", "provider", "type"):
+        if key in data:
+            framework = str(data[key])
+            break
+    explicit_flag = any(
+        key in data and bool(data[key]) for key in ("mlx_lm", "use_mlx_lm")
+    )
+    if framework:
+        if "mlx" not in framework.lower():
+            return None
+    elif not explicit_flag:
+        return None
+
+    model = data.get("model")
+    tokenizer = data.get("tokenizer")
+    if model is None or tokenizer is None:
+        raise ValueError(
+            "mlx_lm configuration must include both 'model' and 'tokenizer' references"
+        )
+
+    generation_kwargs = dict(data.get("generation_kwargs", {}))
+    if "max_tokens" in data and "max_tokens" not in generation_kwargs:
+        generation_kwargs["max_tokens"] = data["max_tokens"]
+
+    config = {
+        "model": model,
+        "tokenizer": tokenizer,
+        "generation_kwargs": generation_kwargs,
+        "use_batch": data.get("use_batch", True),
+    }
+    if "batch_generate" in data:
+        config["batch_generate"] = data["batch_generate"]
+    if "generate" in data:
+        config["generate"] = data["generate"]
+    if "tokenize_kwargs" in data:
+        config["tokenize_kwargs"] = dict(data["tokenize_kwargs"])
+
+    return config
+
+
+def _tokenize_for_mlx(
+    tokenizer: Any, prompt: str, tokenize_kwargs: Optional[Dict[str, Any]] = None
+) -> List[int]:
+    """Convert a prompt string into token IDs expected by ``mlx_lm``."""
+
+    tokenize_kwargs = tokenize_kwargs or {}
+    encoded = tokenizer(prompt, **tokenize_kwargs)
+
+    if hasattr(encoded, "input_ids"):
+        tokens = encoded.input_ids
+    elif isinstance(encoded, Mapping) and "input_ids" in encoded:
+        tokens = encoded["input_ids"]
+    else:
+        tokens = encoded
+
+    if hasattr(tokens, "tolist"):
+        tokens = tokens.tolist()
+
+    if tokens and isinstance(tokens[0], (list, tuple)):
+        tokens = tokens[0]
+
+    return [int(t) for t in tokens]


### PR DESCRIPTION
## Summary
- add an LLM enrichment utility that batches prompts, calls a client, and parses JSON responses into new columns
- allow load_and_prepare to call the enrichment helper when an llm_client is provided
- expand test coverage with a fake LLM client, document configuration guidance in the README, and add mlx-lm integration with dedicated docs and tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d61b3141648320a75e6eea5e9f78ab