### PR TITLE
Preserve LLM-provided text casing in OFX output

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -171,8 +171,8 @@ def test_build_ofx_prefers_llm_enriched_fields():
 
     ofx_text = build_ofx(df, accttype="checking", acctid="12345")
 
-    assert "<NAME>DAILY GRIND COFFEE</NAME>" in ofx_text
-    assert "<MEMO>COFFEE PURCHASE (_DEBIT_)</MEMO>" in ofx_text
+    assert "<NAME>Daily Grind Coffee</NAME>" in ofx_text
+    assert "<MEMO>Coffee purchase (_DEBIT_)</MEMO>" in ofx_text
 
 
 def test_build_ofx_defaults_missing_dtposted(df_without_dates):

--- a/utils/build_ofx.py
+++ b/utils/build_ofx.py
@@ -149,7 +149,6 @@ def build_ofx(
             .fillna("")
             .str.replace(r"\r?\n", " ", regex=True)
             .str.strip()
-            .str.upper()
         )
 
         return (


### PR DESCRIPTION
## Summary
- stop uppercasing OFX name and memo strings so LLM-provided text retains its casing
- update regression test to expect mixed-case LLM results in the rendered OFX

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d6a3f09d5483208ef253e9a090ad52