### PR TITLE
Default llm_model to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ description. The model is asked to emit minified JSON with `payee`, `category`, 
   enrichment step.
 * **Batch sizing** – Adjust `llm_batch_size` to match the provider's rate limits. The
   default of 20 rows keeps requests small and avoids long prompts.
+* **Model selection** – The project defaults to `llm_model="client"`, which expects an
+  object that already knows how to issue completions. Override this with another value
+  (for example, `llm_model="mlx_lm"`) to activate provider-specific integrations.
 * **Cost awareness** – LLM calls can be expensive. Estimate token usage from the
   prompt template and size your batches accordingly. For exploratory runs, point the
   client at a lower-cost model or reduce the batch size.
@@ -47,7 +50,7 @@ from mlx_lm import load as mlx_load
 model, tokenizer = mlx_load("mlx-community/Llama-3.2-3B-Instruct-4bit")
 
 client = {
-    "framework": "mlx_lm",  # tells the helper to use the mlx integration
+    "llm_model": "mlx_lm",  # tells the helper to use the mlx integration
     "model": model,
     "tokenizer": tokenizer,
     "generation_kwargs": {"max_tokens": 128},  # forwarded to mlx_lm.generate

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,7 +18,7 @@ from utils.validate import assert_ofx_ready
 
 from utils.rules import load_rules
 from utils.etl import load_and_prepare
-from utils.llm_enrichment import enrich_transactions_with_llm
+from utils.llm_enrichment import enrich_transactions_with_llm, _resolve_mlx_client_config
 
 
 @pytest.fixture
@@ -289,6 +289,14 @@ class FakeLLMClient:
         return responses
 
 
+def test_resolve_mlx_client_config_defaults_to_client():
+    cfg = {"llm_model": "client", "model": object(), "tokenizer": object()}
+    assert _resolve_mlx_client_config(cfg) is None
+
+    cfg_no_hint = {"model": object(), "tokenizer": object()}
+    assert _resolve_mlx_client_config(cfg_no_hint) is None
+
+
 def test_enrich_transactions_with_llm_batches_and_failures():
     df = pd.DataFrame(
         {
@@ -365,7 +373,7 @@ def test_enrich_transactions_with_llm_supports_mlx(monkeypatch):
     client = {
         "model": object(),
         "tokenizer": fake_tokenizer,
-        "framework": "mlx_lm",
+        "llm_model": "mlx_lm",
         "generation_kwargs": {"max_tokens": 64},
     }
 

--- a/utils/llm_enrichment.py
+++ b/utils/llm_enrichment.py
@@ -248,14 +248,24 @@ def _resolve_mlx_client_config(client: object) -> Optional[Dict[str, Any]]:
     if not data:
         return None
 
+    llm_model_value = str(data.setdefault("llm_model", "client") or "client")
+    llm_model_lower = llm_model_value.lower()
+
     framework = None
-    for key in ("framework", "provider", "type"):
-        if key in data:
-            framework = str(data[key])
-            break
+    if llm_model_lower != "client":
+        framework = llm_model_value
+    else:
+        for key in ("framework", "provider", "type"):
+            if key in data:
+                framework = str(data[key])
+                break
+
     explicit_flag = any(
         key in data and bool(data[key]) for key in ("mlx_lm", "use_mlx_lm")
     )
+    if llm_model_lower != "client":
+        explicit_flag = True
+
     if framework:
         if "mlx" not in framework.lower():
             return None


### PR DESCRIPTION
## Summary
- default the LLM configuration to `llm_model="client"` and treat non-client values as provider hints when resolving mlx-lm clients
- document the new default and update the mlx example configuration in the README
- cover the default behaviour and mlx override with new unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d6e2da19dc8320b49db35754c29f7c